### PR TITLE
Add lenient IMG marker parsing with configurable defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A SillyTavern extension that automatically generates images from `[[IMG: ... ]]` markers in bot messages using your local ComfyUI instance.
 
-When your LLM outputs a marker, ComfyInject intercepts it, sends the prompt to ComfyUI, and replaces the marker with the generated image — all without leaving the chat. Multiple images per message are supported. Images are saved permanently into the chat history and survive page reloads. Outbound prompts sent to the LLM replace injected images with a compact token so the model maintains visual continuity across the conversation.
+When your LLM outputs a marker, ComfyInject intercepts it, sends the prompt to ComfyUI, and replaces the marker with the generated image, all without leaving the chat. Multiple images per message are supported. Images are saved permanently into the chat history and survive page reloads. Outbound prompts sent to the LLM replace injected images with a compact token so the model maintains visual continuity across the conversation.
 
 <details>
   <summary>Table of Contents</summary>
@@ -114,7 +114,7 @@ All other settings have sensible defaults and don't need to be changed to get st
 ComfyInject won't generate anything unless your LLM knows to output the `[[IMG: ... ]]` marker format.
 
 - **To get up and running fast:** copy the ready-made prompt from the [System Prompt](#system-prompt) section and paste it into your character's Post-History Instructions (Author's Note in ST).
-- **To write your own:** see the [Marker Format](#marker-format) section for the full spec.
+- **To write your own:** see the [Marker Format](#marker-format) section for the recommended format and parser behavior.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -165,15 +165,13 @@ All settings are available in the Extensions panel in SillyTavern under **ComfyI
 |---|---|
 | `Shot Tags` | Danbooru tags prepended to the prompt for each SHOT token. Fully customizable. |
 
-### Marker Defaults
+### Marker Repair Notifications
 
 | Setting | Description |
 |---|---|
-| `Default AR` | Fallback AR when marker AR is missing/invalid. Can be `RANDOM` or a fixed AR token. |
-| `Default SHOT` | Fallback SHOT when marker SHOT is missing/invalid. Can be `RANDOM` or a fixed SHOT token. |
-| `Default SEED` | Fallback SEED when marker SEED is missing/invalid. Modes: `RANDOM`, `LOCK`, or `CUSTOM` integer. |
+| `Marker Repair Notifications` | Controls toast notifications for repaired or invalid markers. `All repairs` shows successful repaired markers and parse failures. `Parse failures only` shows only invalid markers. `Off` disables marker repair toasts. |
 
-When `Lock Seed` is enabled, it still takes precedence over marker/default SEED behavior.
+ComfyInject still repairs many malformed markers automatically even when toast notifications are disabled. Full repair details remain visible in the Image Gallery.
 
 > **Note for SDXL users:** Default resolutions are SD1.5 sized (512px). Bump them up — e.g. PORTRAIT to 832x1216.
 
@@ -185,7 +183,7 @@ To reset all advanced settings back to defaults while keeping your host, checkpo
 
 ## Marker Format
 
-Instruct your LLM to output image markers using this exact format:
+The recommended marker format is:
 
 ```
 [[IMG: PROMPT | AR | SHOT | SEED ]]
@@ -194,10 +192,11 @@ Instruct your LLM to output image markers using this exact format:
 Multiple markers per message are supported — each one generates a separate image.
 
 ComfyInject uses a lenient parser:
-- Missing AR/SHOT/SEED fields are auto-filled from **Marker Defaults**.
-- AR/SHOT/SEED can be out of order and are detected by token type.
-- Duplicate AR/SHOT/SEED fields keep the first value and ignore later duplicates.
-- The only parser hard-fail is an empty prompt, shown as `[Image marker invalid: empty prompt]`.
+- Missing AR, SHOT, or SEED fields are auto-filled with built-in parser defaults.
+- AR, SHOT, and SEED can be out of order and are detected by token type.
+- Duplicate AR, SHOT, or SEED fields keep the first value and ignore later duplicates.
+- Large standalone numbers left inside prompt text are preserved and flagged in repair metadata as a possible seed-in-prompt warning.
+- The main parser hard-fails are markers that resolve to an empty prompt or an empty marker body.
 
 ### Segments
 
@@ -218,7 +217,7 @@ ComfyInject uses a lenient parser:
 
 **SHOT** — Camera shot type. Each token prepends Danbooru tags to the positive prompt automatically:
 
-| Token | Tags injected |
+| Token | Tags injected (default) |
 |---|---|
 | `CLOSE` | `close-up, face focus` |
 | `MEDIUM` | `upper body` |
@@ -256,6 +255,8 @@ To change these tags, open the Extensions panel → ComfyInject → **Advanced S
 Add the following to your **Post-History Instructions** (You can also place it in **Author's Note**, **Prompt Content**, or even in your **Summary** if that's what you want!). Placing it there puts it closer to the end of the context window, which gives significantly better format compliance than a top-level system prompt.
 
 The example below tells the LLM to include one image per message. You can change the number to whatever you want, or tell it to include images "when narratively appropriate" for more flexibility.
+
+This prompt teaches the LLM the canonical format. ComfyInject can repair many malformed markers, but better compliance still gives more predictable results.
 
 ```
 IMAGE INJECTION RULES
@@ -300,7 +301,7 @@ If any segment is invalid or missing, regenerate the entire marker before contin
 Never explain or mention the marker in narration.
 ```
 
-> **Model recommendations:** Larger models (70B+) or cloud APIs like DeepSeek V3.2 follow the format far more reliably than small local models. Models under 13B tend to produce inconsistent markers and hallucinate character details.
+> **Model recommendations:** Larger models (70B+) or cloud APIs like DeepSeek V3.2 follow the format far more reliably than small local models. Models under 13B tend to produce inconsistent markers and hallucinate character details. However, with update v0.3.0, many of the previously rejected markers from smaller models will now parse correctly and produce an image regardless. 
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -313,11 +314,16 @@ ComfyInject includes a built-in image gallery accessible from the extension pane
 The gallery shows all generated images in the current chat as a grid of thumbnails. Each thumbnail displays the seed and message number. Click any image to expand it and see the full details:
 
 - **Seed** — the numeric seed used for generation
-- **Prompt** — the full Danbooru tag prompt the LLM wrote
-- **AR** — the aspect ratio token and actual resolution used (shows `LOCKED` if resolution lock was active)
-- **Shot** — the shot type token and actual tags injected (shows `LOCKED` if shot lock was active)
+- **Prompt** — the final prompt sent for generation after parsing salvages and token extraction
+- **AR** — the aspect ratio token and actual resolution used
+- **Shot** — the shot type token and actual tags injected
 - **Filename** — the output filename in ComfyUI's output folder
 - **Prompt ID** — the ComfyUI job ID, clickable as a link to the ComfyUI history endpoint for debugging
+
+If an image marker was repaired during parsing, the thumbnail shows a warning badge. In the detail view, a Repair Info section shows:
+- which fields were defaulted
+- which duplicate AR / SHOT / SEED tokens were ignored
+- whether a possible seed remained in the prompt
 
 The gallery always reflects what's currently on screen — swiping to a different response updates the gallery accordingly.
 
@@ -350,11 +356,11 @@ To use your own workflow, see `workflows/README.md` for placeholder requirements
 ## How It Works
 
 1. Bot message arrives containing one or more `[[IMG: ... ]]` markers
-2. ComfyInject parses each marker and resolves seeds, applying any active locks
+2. ComfyInject parses each marker, salvages misplaced control tokens when possible, applies built-in fallbacks for missing fields, and resolves seeds while applying any active locks
 3. For each marker, the workflow is filled with your settings and sent to ComfyUI sequentially
 4. ComfyInject polls `/history` until each image is ready
 5. Each marker is replaced with an `<img>` tag in the chat permanently
-6. Image metadata (seed, AR, shot, prompt ID, filename) is saved to chat metadata keyed by message timestamp for stability across deletions
+6. Image metadata (AR, shot, prompt ID, filename, effective settings, and repair metadata) is saved to chat metadata keyed by message timestamp for stability across deletions
 7. On the next generation, the outbound interceptor replaces `<img>` tags with `[[IMG: prompt | seed ]]` tokens so the LLM sees a compact text reference instead of raw HTML
 8. Retry buttons are injected via DOM manipulation after each render
 
@@ -431,6 +437,9 @@ A few things to check:
 - Make sure the Checkpoint field in ComfyInject's settings matches your model filename exactly, including the file extension
 - Make sure the Workflow field points to a valid workflow JSON in the `workflows/` folder
 - Check the browser console for any error messages from ComfyInject
+- If the marker resolves to an empty prompt or empty marker body, ComfyInject will replace it inline with a parse error instead of generating an image
+- For successful repaired markers, check the Image Gallery for repair details
+- For failed markers, check the browser console for parse or generation failure details, including the original failed marker when available
 - Make sure your LLM is outputting the marker in the correct format — see the [Marker Format](#marker-format) section
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>

--- a/README.md
+++ b/README.md
@@ -165,6 +165,16 @@ All settings are available in the Extensions panel in SillyTavern under **ComfyI
 |---|---|
 | `Shot Tags` | Danbooru tags prepended to the prompt for each SHOT token. Fully customizable. |
 
+### Marker Defaults
+
+| Setting | Description |
+|---|---|
+| `Default AR` | Fallback AR when marker AR is missing/invalid. Can be `RANDOM` or a fixed AR token. |
+| `Default SHOT` | Fallback SHOT when marker SHOT is missing/invalid. Can be `RANDOM` or a fixed SHOT token. |
+| `Default SEED` | Fallback SEED when marker SEED is missing/invalid. Modes: `RANDOM`, `LOCK`, or `CUSTOM` integer. |
+
+When `Lock Seed` is enabled, it still takes precedence over marker/default SEED behavior.
+
 > **Note for SDXL users:** Default resolutions are SD1.5 sized (512px). Bump them up — e.g. PORTRAIT to 832x1216.
 
 To reset all advanced settings back to defaults while keeping your host, checkpoint, and workflow, press the **Reset Advanced to Defaults** button at the bottom of the Advanced Settings panel.
@@ -182,6 +192,12 @@ Instruct your LLM to output image markers using this exact format:
 ```
 
 Multiple markers per message are supported — each one generates a separate image.
+
+ComfyInject uses a lenient parser:
+- Missing AR/SHOT/SEED fields are auto-filled from **Marker Defaults**.
+- AR/SHOT/SEED can be out of order and are detected by token type.
+- Duplicate AR/SHOT/SEED fields keep the first value and ignore later duplicates.
+- The only parser hard-fail is an empty prompt, shown as `[Image marker invalid: empty prompt]`.
 
 ### Segments
 

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "optional": [],
   "js": "index.js",
   "author": "K",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "homePage": "https://github.com/Spadic21/ComfyInject",
   "description": "Parses [[IMG: ... ]] markers and injects ComfyUI images into chat.",
   "auto_update": false,

--- a/settings.html
+++ b/settings.html
@@ -231,7 +231,7 @@
                                 id="comfyinject_seed_lock_value"
                                 class="text_pole"
                                 min="0"
-                                max="4294967295"
+                                max="9007199254740991"
                                 step="1"
                                 style="width: 150px;"
                             />
@@ -241,68 +241,16 @@
 
                 <hr class="sysHR" />
 
-                <!-- Marker Defaults -->
-                <div class="flex-container flexGap5">
-                    <div id="comfyinject_marker_defaults_toggle" class="menu_button menu_button_icon">
-                        <i class="fa-solid fa-wand-magic-sparkles"></i>
-                        <span>Marker Defaults</span>
-                    </div>
+                <!-- Marker Repair Notifications -->
+                <div class="flex-container flexGap5 alignItemsCenter">
+                    <label for="comfyinject_repair_toast_mode">Marker Repair Notifications</label>
+                    <select id="comfyinject_repair_toast_mode" class="text_pole">
+                        <option value="all">All repairs</option>
+                        <option value="failures">Parse failures only</option>
+                        <option value="off">Off</option>
+                    </select>
                 </div>
-
-                <div id="comfyinject_marker_defaults_block" style="display:none;">
-                    <small>Fallback values used when marker fields are missing or out of order.</small>
-                    <br />
-
-                    <div class="flex-container flexGap5 alignItemsCenter" style="margin-top: 8px;">
-                        <label style="width: 80px;" for="comfyinject_default_ar">Default AR</label>
-                        <select id="comfyinject_default_ar" class="text_pole" style="width: 170px;">
-                            <option value="RANDOM">RANDOM</option>
-                            <option value="PORTRAIT">PORTRAIT</option>
-                            <option value="SQUARE">SQUARE</option>
-                            <option value="LANDSCAPE">LANDSCAPE</option>
-                            <option value="CINEMA">CINEMA</option>
-                        </select>
-                    </div>
-
-                    <div class="flex-container flexGap5 alignItemsCenter" style="margin-top: 6px;">
-                        <label style="width: 80px;" for="comfyinject_default_shot">Default SHOT</label>
-                        <select id="comfyinject_default_shot" class="text_pole" style="width: 170px;">
-                            <option value="RANDOM">RANDOM</option>
-                            <option value="CLOSE">CLOSE</option>
-                            <option value="MEDIUM">MEDIUM</option>
-                            <option value="WIDE">WIDE</option>
-                            <option value="DUTCH">DUTCH</option>
-                            <option value="OVERHEAD">OVERHEAD</option>
-                            <option value="LOWANGLE">LOWANGLE</option>
-                            <option value="HIGHANGLE">HIGHANGLE</option>
-                            <option value="PROFILE">PROFILE</option>
-                            <option value="BACKVIEW">BACKVIEW</option>
-                            <option value="POV">POV</option>
-                        </select>
-                    </div>
-
-                    <div class="flex-container flexGap5 alignItemsCenter" style="margin-top: 6px;">
-                        <label style="width: 80px;" for="comfyinject_default_seed_mode">Default SEED</label>
-                        <select id="comfyinject_default_seed_mode" class="text_pole" style="width: 170px;">
-                            <option value="RANDOM">RANDOM</option>
-                            <option value="LOCK">LOCK</option>
-                            <option value="CUSTOM">CUSTOM</option>
-                        </select>
-                    </div>
-
-                    <div id="comfyinject_default_seed_custom_input" class="flex-container flexGap5 alignItemsCenter" style="margin-top: 6px; display:none;">
-                        <label style="width: 80px;" for="comfyinject_default_seed_value">Seed</label>
-                        <input
-                            type="number"
-                            id="comfyinject_default_seed_value"
-                            class="text_pole"
-                            min="0"
-                            max="1125899906842624"
-                            step="1"
-                            style="width: 170px;"
-                        />
-                    </div>
-                </div>
+                <small>Controls toast notifications for repaired or invalid image markers.</small>
 
                 <hr class="sysHR" />
 

--- a/settings.html
+++ b/settings.html
@@ -241,6 +241,71 @@
 
                 <hr class="sysHR" />
 
+                <!-- Marker Defaults -->
+                <div class="flex-container flexGap5">
+                    <div id="comfyinject_marker_defaults_toggle" class="menu_button menu_button_icon">
+                        <i class="fa-solid fa-wand-magic-sparkles"></i>
+                        <span>Marker Defaults</span>
+                    </div>
+                </div>
+
+                <div id="comfyinject_marker_defaults_block" style="display:none;">
+                    <small>Fallback values used when marker fields are missing or out of order.</small>
+                    <br />
+
+                    <div class="flex-container flexGap5 alignItemsCenter" style="margin-top: 8px;">
+                        <label style="width: 80px;" for="comfyinject_default_ar">Default AR</label>
+                        <select id="comfyinject_default_ar" class="text_pole" style="width: 170px;">
+                            <option value="RANDOM">RANDOM</option>
+                            <option value="PORTRAIT">PORTRAIT</option>
+                            <option value="SQUARE">SQUARE</option>
+                            <option value="LANDSCAPE">LANDSCAPE</option>
+                            <option value="CINEMA">CINEMA</option>
+                        </select>
+                    </div>
+
+                    <div class="flex-container flexGap5 alignItemsCenter" style="margin-top: 6px;">
+                        <label style="width: 80px;" for="comfyinject_default_shot">Default SHOT</label>
+                        <select id="comfyinject_default_shot" class="text_pole" style="width: 170px;">
+                            <option value="RANDOM">RANDOM</option>
+                            <option value="CLOSE">CLOSE</option>
+                            <option value="MEDIUM">MEDIUM</option>
+                            <option value="WIDE">WIDE</option>
+                            <option value="DUTCH">DUTCH</option>
+                            <option value="OVERHEAD">OVERHEAD</option>
+                            <option value="LOWANGLE">LOWANGLE</option>
+                            <option value="HIGHANGLE">HIGHANGLE</option>
+                            <option value="PROFILE">PROFILE</option>
+                            <option value="BACKVIEW">BACKVIEW</option>
+                            <option value="POV">POV</option>
+                        </select>
+                    </div>
+
+                    <div class="flex-container flexGap5 alignItemsCenter" style="margin-top: 6px;">
+                        <label style="width: 80px;" for="comfyinject_default_seed_mode">Default SEED</label>
+                        <select id="comfyinject_default_seed_mode" class="text_pole" style="width: 170px;">
+                            <option value="RANDOM">RANDOM</option>
+                            <option value="LOCK">LOCK</option>
+                            <option value="CUSTOM">CUSTOM</option>
+                        </select>
+                    </div>
+
+                    <div id="comfyinject_default_seed_custom_input" class="flex-container flexGap5 alignItemsCenter" style="margin-top: 6px; display:none;">
+                        <label style="width: 80px;" for="comfyinject_default_seed_value">Seed</label>
+                        <input
+                            type="number"
+                            id="comfyinject_default_seed_value"
+                            class="text_pole"
+                            min="0"
+                            max="1125899906842624"
+                            step="1"
+                            style="width: 170px;"
+                        />
+                    </div>
+                </div>
+
+                <hr class="sysHR" />
+
                 <!-- Max Poll Attempts -->
                 <div class="flex-container flexGap5 alignItemsCenter">
                     <label for="comfyinject_max_poll_attempts">Max Poll Attempts</label>

--- a/settings.js
+++ b/settings.js
@@ -66,6 +66,13 @@ export const defaultSettings = Object.freeze({
     seed_lock_mode: "RANDOM",
     seed_lock_value: 0,
 
+    // --- Marker Defaults ---
+    // Used when marker segments are missing or out-of-order.
+    // AR/SHOT accept RANDOM plus valid tokens; SEED accepts RANDOM, LOCK, or integer.
+    default_ar: "RANDOM",
+    default_shot: "RANDOM",
+    default_seed: "RANDOM",
+
     // --- Shot Tags ---
     // Danbooru-style tags prepended to the positive prompt for each SHOT token.
     // Edit these to match your model's preferred framing vocabulary.

--- a/settings.js
+++ b/settings.js
@@ -66,12 +66,12 @@ export const defaultSettings = Object.freeze({
     seed_lock_mode: "RANDOM",
     seed_lock_value: 0,
 
-    // --- Marker Defaults ---
-    // Used when marker segments are missing or out-of-order.
-    // AR/SHOT accept RANDOM plus valid tokens; SEED accepts RANDOM, LOCK, or integer.
-    default_ar: "RANDOM",
-    default_shot: "RANDOM",
-    default_seed: "RANDOM",
+    // --- Marker Repair Notifications ---
+    // Controls when parser repair toasts are shown.
+    // "all" = successful repaired markers + parse failures
+    // "failures" = parse failures only
+    // "off" = no marker repair toasts
+    repair_toast_mode: "failures",
 
     // --- Shot Tags ---
     // Danbooru-style tags prepended to the positive prompt for each SHOT token.

--- a/src/dom.js
+++ b/src/dom.js
@@ -143,7 +143,20 @@ async function processMessage(index) {
             message.mes = message.mes.replace(MARKER_REGEX, imgTag);
             metadataArray.push({ seed, ar, shot, promptId, filename, effectiveAr, effectiveShot, resolution, shotTags });
         } else if (result?.status === "parse_error") {
-            message.mes = message.mes.replace(MARKER_REGEX, `<span class="comfyinject-error">[Image marker invalid: empty prompt]</span>`);
+            const reason = result?.reason;
+            let errorText;
+            switch (reason) {
+                case "empty_prompt":
+                    errorText = "[Image marker invalid: empty prompt]";
+                    break;
+                case "unknown":
+                    errorText = "[Image marker invalid: unknown parse error]";
+                    break;
+                default:
+                    errorText = "[Image marker invalid]";
+                    break;
+            }
+            message.mes = message.mes.replace(MARKER_REGEX, `<span class="comfyinject-error">${errorText}</span>`);
             metadataArray.push(null);
         } else {
             // Generation failed for this marker — replace with error text

--- a/src/dom.js
+++ b/src/dom.js
@@ -137,11 +137,14 @@ async function processMessage(index) {
     // Replace each marker with its image tag (or error), one at a time
     const metadataArray = [];
     for (const result of results) {
-        if (result) {
+        if (result?.status === "ok") {
             const { imageUrl, seed, prompt, ar, shot, promptId, filename, effectiveAr, effectiveShot, resolution, shotTags } = result;
             const imgTag = buildImgTag(imageUrl, prompt, seed);
             message.mes = message.mes.replace(MARKER_REGEX, imgTag);
             metadataArray.push({ seed, ar, shot, promptId, filename, effectiveAr, effectiveShot, resolution, shotTags });
+        } else if (result?.status === "parse_error") {
+            message.mes = message.mes.replace(MARKER_REGEX, `<span class="comfyinject-error">[Image marker invalid: empty prompt]</span>`);
+            metadataArray.push(null);
         } else {
             // Generation failed for this marker — replace with error text
             message.mes = message.mes.replace(MARKER_REGEX, `<span class="comfyinject-error">[Image generation failed]</span>`);

--- a/src/dom.js
+++ b/src/dom.js
@@ -29,6 +29,127 @@ function findIndexBySendDate(sendDate) {
 }
 
 /**
+ * Returns the current marker repair toast mode.
+ * @returns {"all" | "failures" | "off"}
+ */
+function getRepairToastMode() {
+    return SillyTavern.getContext().extensionSettings[MODULE_NAME]?.repair_toast_mode || "failures";
+}
+
+/**
+ * Returns true if a repairMeta object contains any meaningful repair info.
+ * Non-canonical formatting alone does not count unless something was actually
+ * defaulted, ignored, or flagged.
+ * @param {object|null} repairMeta
+ * @returns {boolean}
+ */
+function hasMeaningfulRepair(repairMeta) {
+    if (!repairMeta || typeof repairMeta !== "object") return false;
+
+    const defaulted = Array.isArray(repairMeta.defaulted) ? repairMeta.defaulted : [];
+    const duplicateTokens = repairMeta.duplicateTokens || {};
+
+    const duplicateAr = Array.isArray(duplicateTokens.AR) ? duplicateTokens.AR : [];
+    const duplicateShot = Array.isArray(duplicateTokens.SHOT) ? duplicateTokens.SHOT : [];
+    const duplicateSeed = Array.isArray(duplicateTokens.SEED) ? duplicateTokens.SEED : [];
+
+    return (
+        defaulted.length > 0 ||
+        duplicateAr.length > 0 ||
+        duplicateShot.length > 0 ||
+        duplicateSeed.length > 0 ||
+        repairMeta.possibleSeedInPrompt === true
+    );
+}
+
+/**
+ * Shows a grouped repair toast for one live-rendered message.
+ * This is only used for successful repaired markers.
+ * @param {number} repairedCount
+ * @param {number} totalCount
+ */
+function maybeShowGroupedRepairToast(repairedCount, totalCount) {
+    if (getRepairToastMode() !== "all") return;
+    if (repairedCount <= 0) return;
+
+    toastr.warning(
+        `Repaired ${repairedCount}/${totalCount} markers in this message. See Image Gallery for details.`,
+        "ComfyInject"
+    );
+}
+
+/**
+ * Logs a grouped repair warning for one live-rendered message.
+ * This mirrors the user-facing grouped repair toast.
+ * @param {number} messageIndex
+ * @param {number} repairedCount
+ * @param {number} totalCount
+ */
+function maybeLogGroupedRepairWarning(messageIndex, repairedCount, totalCount) {
+    if (getRepairToastMode() !== "all") return;
+    if (repairedCount <= 0) return;
+
+    console.warn("[ComfyInject] Repaired markers in message:", {
+        messageIndex,
+        repairedCount,
+        totalCount,
+    });
+}
+
+/**
+ * Shows a parse-failure toast based on the user's marker repair toast setting.
+ * @param {string} errorText
+ */
+function maybeShowParseFailureToast(errorText) {
+    const mode = getRepairToastMode();
+    if (mode === "off") return;
+
+    toastr.warning(errorText, "ComfyInject");
+}
+
+/**
+ * Shows one bulk-scan repair summary toast after scanning old messages.
+ * This avoids spamming one toast per message during chat load.
+ * @param {number} repairedMessages
+ * @param {number} repairedMarkers
+ */
+function maybeShowBulkRepairSummaryToast(repairedMessages, repairedMarkers) {
+    if (getRepairToastMode() !== "all") return;
+    if (repairedMarkers <= 0) return;
+
+    toastr.warning(
+        `Repaired ${repairedMarkers} markers across ${repairedMessages} existing messages. See Image Gallery for details.`,
+        "ComfyInject"
+    );
+}
+
+/**
+ * Logs one bulk-scan repair summary warning after scanning old messages.
+ * @param {number} repairedMessages
+ * @param {number} repairedMarkers
+ */
+function maybeLogBulkRepairSummaryWarning(repairedMessages, repairedMarkers) {
+    if (getRepairToastMode() !== "all") return;
+    if (repairedMarkers <= 0) return;
+
+    console.warn("[ComfyInject] Repaired markers during bulk scan:", {
+        repairedMessages,
+        repairedMarkers,
+    });
+}
+
+/**
+ * Formats a marker position label within a message.
+ * Only includes numbering when the message had multiple markers.
+ * @param {number} markerNumber - 1-based marker number within the message
+ * @param {number} totalMarkers - Total markers in the message
+ * @returns {string}
+ */
+function formatMarkerPosition(markerNumber, totalMarkers) {
+    return totalMarkers > 1 ? ` ${markerNumber}/${totalMarkers}` : "";
+}
+
+/**
  * Adds retry buttons to all rendered comfyinject images in a message.
  * This is done via DOM manipulation (not in message.mes) because
  * ST's HTML sanitizer strips custom divs when rendering messages.
@@ -97,18 +218,19 @@ function addAllRetryButtons() {
  * saves metadata keyed by send_date, and calls saveChat().
  * @param {number} index - The message index in the chat array
  */
-async function processMessage(index) {
+async function processMessage(index, options = {}) {
     const context = SillyTavern.getContext();
     const message = context.chat[index];
     const { updateMessageBlock } = SillyTavern.getContext();
+    const { suppressRepairNotifications = false } = options;
 
-    if (!message) return;
+    if (!message) return { repairedCount: 0, totalCount: 0 };
 
     // Only process bot messages
-    if (message.is_user) return;
+    if (message.is_user) return { repairedCount: 0, totalCount: 0 };
 
     // Skip if no marker present
-    if (!hasImageMarker(message.mes)) return;
+    if (!hasImageMarker(message.mes)) return { repairedCount: 0, totalCount: 0 };
 
     console.log(`[ComfyInject] Processing message ${index}`);
 
@@ -132,36 +254,112 @@ async function processMessage(index) {
     // Process all markers sequentially
     const results = await processAllImageMarkers(message.mes, index);
 
-    if (results.length === 0) return;
+    if (results.length === 0) return { repairedCount: 0, totalCount: 0 };
 
-    // Replace each marker with its image tag (or error), one at a time
+    // Replace each marker with either a generated image or a structured error state.
+    // Only successful generations should be saved into metadata.
     const metadataArray = [];
-    for (const result of results) {
+    let repairedCount = 0;
+
+    for (let markerIndex = 0; markerIndex < results.length; markerIndex++) {
+        const result = results[markerIndex];
+        const markerNumber = markerIndex + 1;
+        const markerPosition = formatMarkerPosition(markerNumber, results.length);
+
         if (result?.status === "ok") {
-            const { imageUrl, seed, prompt, ar, shot, promptId, filename, effectiveAr, effectiveShot, resolution, shotTags } = result;
+            const {
+                imageUrl,
+                seed,
+                prompt,
+                ar,
+                shot,
+                promptId,
+                filename,
+                effectiveAr,
+                effectiveShot,
+                resolution,
+                shotTags,
+                repairMeta,
+            } = result;
+
+            if (hasMeaningfulRepair(repairMeta)) {
+                repairedCount++;
+            }
+
             const imgTag = buildImgTag(imageUrl, prompt, seed);
             message.mes = message.mes.replace(MARKER_REGEX, imgTag);
-            metadataArray.push({ seed, ar, shot, promptId, filename, effectiveAr, effectiveShot, resolution, shotTags });
+            metadataArray.push({
+                ar,
+                shot,
+                promptId,
+                filename,
+                effectiveAr,
+                effectiveShot,
+                resolution,
+                shotTags,
+                repairMeta,
+            });
         } else if (result?.status === "parse_error") {
+            // The marker was found, but parsing could not recover a usable prompt.
             const reason = result?.reason;
             let errorText;
             switch (reason) {
                 case "empty_prompt":
-                    errorText = "[Image marker invalid: empty prompt]";
+                    errorText = `[Image marker${markerPosition} invalid: empty prompt]`;
                     break;
-                case "unknown":
-                    errorText = "[Image marker invalid: unknown parse error]";
+                case "empty_marker":
+                    errorText = `[Image marker${markerPosition} invalid: empty marker]`;
                     break;
                 default:
-                    errorText = "[Image marker invalid]";
+                    errorText = `[Image marker${markerPosition} invalid]`;
                     break;
             }
-            message.mes = message.mes.replace(MARKER_REGEX, `<span class="comfyinject-error">${errorText}</span>`);
-            metadataArray.push(null);
+
+            console.warn("[ComfyInject] Image marker parse failed:", {
+                reason,
+                rawMarker: result?.rawMarker || null,
+                messageIndex: index,
+                markerNumber,
+                totalMarkers: results.length,
+            });
+
+            if (!suppressRepairNotifications) {
+                maybeShowParseFailureToast(errorText);
+            }
+
+            message.mes = message.mes.replace(
+                MARKER_REGEX,
+                `<span class="comfyinject-error">${errorText}</span>`
+            );
+        } else if (result?.status === "generation_error") {
+            // Marker parsed successfully, but image generation failed.
+            const errorText = `[Image generation failed${markerPosition ? `: marker${markerPosition}` : ""}]`;
+
+            console.error("[ComfyInject] Image generation failed:", {
+                messageIndex: index,
+                markerNumber,
+                totalMarkers: results.length,
+            });
+
+            message.mes = message.mes.replace(
+                MARKER_REGEX,
+                `<span class="comfyinject-error">${errorText}</span>`
+            );
         } else {
-            // Generation failed for this marker — replace with error text
-            message.mes = message.mes.replace(MARKER_REGEX, `<span class="comfyinject-error">[Image generation failed]</span>`);
-            metadataArray.push(null);
+            // Fallback guard for any unexpected result shape.
+            const errorText = `[Image generation failed${markerPosition ?`: marker${markerPosition}` : ""}]`;
+
+            console.error("[ComfyInject] Unexpected marker result shape:", {
+                result,
+                messageIndex: index,
+                markerNumber,
+                totalMarkers: results.length,
+            });
+
+            message.mes = message.mes.replace(
+                MARKER_REGEX,
+                `<span class="comfyinject-error">${errorText}</span>`
+            );
         }
     }
 
@@ -186,7 +384,18 @@ async function processMessage(index) {
     await context.saveMetadata();
     await context.saveChat();
 
-    console.log(`[ComfyInject] Message ${index} saved with ${results.filter(Boolean).length} injected image(s)`);
+    if (!suppressRepairNotifications) {
+        maybeShowGroupedRepairToast(repairedCount, results.length);
+        maybeLogGroupedRepairWarning(index, repairedCount, results.length);
+    }
+
+    const successCount = results.filter((result) => result?.status === "ok").length;
+    console.log(`[ComfyInject] Message ${index} saved with ${successCount} injected image(s)`);
+
+    return {
+        repairedCount,
+        totalCount: results.length,
+    };
 }
 
 /**
@@ -200,12 +409,23 @@ async function scanExistingMessages() {
 
     console.log(`[ComfyInject] Scanning ${context.chat.length} existing messages`);
 
+    let repairedMessages = 0;
+    let repairedMarkers = 0;
+
     for (let i = 0; i < context.chat.length; i++) {
         const message = context.chat[i];
         if (!message.is_user && hasImageMarker(message.mes)) {
-            await processMessage(i);
+            const summary = await processMessage(i, { suppressRepairNotifications: true });
+
+            if (summary?.repairedCount > 0) {
+                repairedMessages++;
+                repairedMarkers += summary.repairedCount;
+            }
         }
     }
+
+    maybeShowBulkRepairSummaryToast(repairedMessages, repairedMarkers);
+    maybeLogBulkRepairSummaryWarning(repairedMessages, repairedMarkers);
 
     // Add retry buttons to all already-rendered images (including ones from previous sessions)
     addAllRetryButtons();
@@ -245,8 +465,13 @@ async function retryImage(sendDate, imgIndex) {
 
     const { ar, shot } = imageData;
 
-    // Generate a new random seed
-    const newSeed = Math.floor(Math.random() * 4294967295);
+    // Fall back to the same marker-level defaults used by the parser
+    // if metadata is missing or incomplete.
+    const retryAr = ar || "SQUARE";
+    const retryShot = shot || "MEDIUM";
+
+    // Generate a new random seed using the shared project-wide max safe integer range.
+    const newSeed = Math.floor(Math.random() * 9007199254740991);
 
     // Show generating state on the retry button
     const retryBtn = document.querySelector(`.comfyinject-retry[data-senddate="${sendDate}"][data-imgindex="${imgIndex}"]`);
@@ -259,8 +484,8 @@ async function retryImage(sendDate, imgIndex) {
     try {
         result = await generateImage({
             prompt,
-            ar: ar || "PORTRAIT",
-            shot: shot || "WIDE",
+            ar: retryAr,
+            shot: retryShot,
             seed: newSeed,
             messageIndex,
             bypassSeedLock: true,
@@ -281,13 +506,43 @@ async function retryImage(sendDate, imgIndex) {
     // Save the seed that was actually used so LOCK works
     saveLastSeed(effectiveSeed);
 
-    // Update metadata — try send_date key first, fall back to index for legacy
+    // Update metadata — try send_date key first, fall back to index for legacy.
+    // Guard against missing or malformed entries so retry does not recreate bad metadata.
     const metaKey = metadata[sendDate] ? sendDate : messageIndex;
     const metaEntry = metadata[metaKey];
+
     if (Array.isArray(metaEntry)) {
-        metaEntry[imgIndex] = { ...metaEntry[imgIndex], seed: effectiveSeed, promptId, filename, effectiveAr, effectiveShot, resolution, shotTags };
-    } else if (metaEntry) {
-        metadata[metaKey] = { ...metaEntry, seed: effectiveSeed, promptId, filename, effectiveAr, effectiveShot, resolution, shotTags };
+        const existingEntry = metaEntry[imgIndex] && typeof metaEntry[imgIndex] === "object"
+            ? metaEntry[imgIndex]
+            : {};
+
+        metaEntry[imgIndex] = {
+            ...existingEntry,
+            seed: effectiveSeed,
+            ar: existingEntry.ar || retryAr,
+            shot: existingEntry.shot || retryShot,
+            promptId,
+            filename,
+            effectiveAr,
+            effectiveShot,
+            resolution,
+            shotTags,
+            repairMeta: existingEntry.repairMeta || null,
+        };
+    } else if (metaEntry && typeof metaEntry === "object") {
+        metadata[metaKey] = {
+            ...metaEntry,
+            seed: effectiveSeed,
+            ar: metaEntry.ar || retryAr,
+            shot: metaEntry.shot || retryShot,
+            promptId,
+            filename,
+            effectiveAr,
+            effectiveShot,
+            resolution,
+            shotTags,
+            repairMeta: metaEntry.repairMeta || null,
+        };
     }
 
     // Replace the Nth img tag in mes (where N = imgIndex)

--- a/src/gallery.js
+++ b/src/gallery.js
@@ -2,6 +2,24 @@ import { MODULE_NAME } from "../settings.js";
 import { getImageData } from "./state.js";
 
 /**
+ * Returns true if the image has any repair metadata worth surfacing in the UI.
+ * @param {object | null} repairMeta
+ * @returns {boolean}
+ */
+function hasRepairInfo(repairMeta) {
+    if (!repairMeta || typeof repairMeta !== "object") return false;
+
+    const defaulted = Array.isArray(repairMeta.defaulted) ? repairMeta.defaulted : [];
+    const duplicateTokens = repairMeta.duplicateTokens || {};
+    const duplicateCount =
+        (Array.isArray(duplicateTokens.AR) ? duplicateTokens.AR.length : 0) +
+        (Array.isArray(duplicateTokens.SHOT) ? duplicateTokens.SHOT.length : 0) +
+        (Array.isArray(duplicateTokens.SEED) ? duplicateTokens.SEED.length : 0);
+
+    return defaulted.length > 0 || duplicateCount > 0 || repairMeta.possibleSeedInPrompt === true;
+}
+
+/**
  * Opens the image gallery modal showing all generated images in the current chat.
  * Images are displayed as thumbnails with seeds. Clicking expands to full detail view.
  */
@@ -14,7 +32,8 @@ export function openGallery() {
 
     // Collect all images by scanning the actual current mes content of each message.
     // This ensures the gallery always matches what's on screen regardless of swipe state.
-    // Metadata is used as supplementary info for extra fields like ar, shot, promptId.
+    // Metadata is used as supplementary info for extra fields like ar, shot,
+    // promptId, and parser repair metadata.
     const allImages = [];
     const imgTagRegex = /<img class="comfyinject-image"[^>]*>/g;
     const srcRegex = /src="([^"]*)"/;
@@ -28,9 +47,8 @@ export function openGallery() {
         const imgTags = [...message.mes.matchAll(imgTagRegex)];
         if (imgTags.length === 0) continue;
 
-        const metaImages = message.send_date && getImageData(metadata, message.send_date).length > 0
-            ? getImageData(metadata, message.send_date)
-            : getImageData(metadata, i);
+        const sendDateImages = message.send_date ? getImageData(metadata, message.send_date) : [];
+        const metaImages = sendDateImages.length > 0 ? sendDateImages : getImageData(metadata, i);
 
         imgTags.forEach((match, imgIndex) => {
             const tag = match[0];
@@ -38,7 +56,8 @@ export function openGallery() {
             const prompt = tag.match(promptRegex)?.[1]?.replace(/&quot;/g, '"') || "";
             const seed = parseInt(tag.match(seedRegex)?.[1], 10) || 0;
 
-            // Metadata is supplementary — only use it for extra fields (ar, shot, promptId)
+            // Metadata is supplementary — only use it for extra fields
+            // like ar, shot, promptId, effective settings, and repair metadata.
             // and only if the seed matches the current img tag (avoids stale swipe data)
             const meta = metaImages[imgIndex] || {};
             const metaMatches = meta.seed === seed;
@@ -55,6 +74,7 @@ export function openGallery() {
                 effectiveShot: metaMatches ? (meta.effectiveShot || null) : null,
                 resolution: metaMatches ? (meta.resolution || null) : null,
                 shotTags: metaMatches ? (meta.shotTags || null) : null,
+                repairMeta: metaMatches ? (meta.repairMeta || null) : null,
                 messageIndex: i,
                 imgIndex,
             });
@@ -133,6 +153,32 @@ export function openGallery() {
         `;
 
         card.appendChild(thumb);
+
+        // Show a small badge if the marker was repaired/defaulted during parsing.
+        if (hasRepairInfo(img.repairMeta)) {
+            const badge = document.createElement("div");
+            badge.title = "This image used repaired/defaulted marker fields";
+            badge.textContent = "⚠";
+            badge.style.cssText = `
+                position: absolute;
+                top: 8px;
+                left: 8px;
+                width: 22px;
+                height: 22px;
+                border-radius: 999px;
+                background: rgba(255, 170, 0, 0.9);
+                color: black;
+                font-weight: bold;
+                font-size: 13px;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                box-shadow: 0 2px 6px rgba(0,0,0,0.35);
+            `;
+            card.style.position = "relative";
+            card.appendChild(badge);
+        }
+
         card.appendChild(info);
 
         // Click to expand
@@ -258,6 +304,82 @@ function showDetail(img, overlay) {
     }
 
     detail.appendChild(infoTable);
+
+    // Repair info block
+    if (hasRepairInfo(img.repairMeta)) {
+        const repairMeta = img.repairMeta || {};
+        const defaulted = Array.isArray(repairMeta.defaulted) ? repairMeta.defaulted : [];
+        const duplicateTokens = repairMeta.duplicateTokens || {};
+
+        const repairSection = document.createElement("div");
+        repairSection.style.cssText = `
+            margin-top: 16px;
+            background: rgba(255, 170, 0, 0.08);
+            border: 1px solid rgba(255, 170, 0, 0.25);
+            border-radius: 8px;
+            padding: 16px;
+            color: white;
+        `;
+
+        const title = document.createElement("div");
+        title.style.cssText = "font-weight: bold; margin-bottom: 10px; color: #ffcc66;";
+        title.textContent = "Repair Info";
+        repairSection.appendChild(title);
+
+        const repairList = document.createElement("div");
+        repairList.style.cssText = `
+            display: grid;
+            grid-template-columns: auto 1fr;
+            gap: 8px 16px;
+            font-size: 13px;
+        `;
+
+        const rows = [
+            [
+                "Defaulted",
+                defaulted.length > 0 ? defaulted.join(", ") : "None",
+            ],
+            [
+                "Duplicate AR",
+                Array.isArray(duplicateTokens.AR) && duplicateTokens.AR.length > 0
+                    ? duplicateTokens.AR.join(", ")
+                    : "None",
+            ],
+            [
+                "Duplicate SHOT",
+                Array.isArray(duplicateTokens.SHOT) && duplicateTokens.SHOT.length > 0
+                    ? duplicateTokens.SHOT.join(", ")
+                    : "None",
+            ],
+            [
+                "Duplicate SEED",
+                Array.isArray(duplicateTokens.SEED) && duplicateTokens.SEED.length > 0
+                    ? duplicateTokens.SEED.join(", ")
+                    : "None",
+            ],
+            [
+                "Possible Seed In Prompt",
+                repairMeta.possibleSeedInPrompt ? "Yes" : "No",
+            ],
+        ];
+
+        for (const [label, value] of rows) {
+            const labelEl = document.createElement("span");
+            labelEl.style.cssText = "color: #d9b15c; font-weight: bold; white-space: nowrap;";
+            labelEl.textContent = label;
+
+            const valueEl = document.createElement("span");
+            valueEl.style.cssText = "color: #eee; word-break: break-word;";
+            valueEl.textContent = value;
+
+            repairList.appendChild(labelEl);
+            repairList.appendChild(valueEl);
+        }
+
+        repairSection.appendChild(repairList);
+        detail.appendChild(repairSection);
+    }
+
     overlay.appendChild(detail);
 }
 

--- a/src/parse.js
+++ b/src/parse.js
@@ -1,13 +1,21 @@
 import { generateImage } from "./comfy.js";
 import { resolveSeed, saveLastSeed } from "./state.js";
+import { MODULE_NAME } from "../settings.js";
 
 // Valid values for AR and SHOT tokens
 const VALID_AR   = new Set(["PORTRAIT", "SQUARE", "LANDSCAPE", "CINEMA"]);
 const VALID_SHOT = new Set(["CLOSE", "MEDIUM", "WIDE", "DUTCH", "OVERHEAD", "LOWANGLE", "HIGHANGLE", "PROFILE", "BACKVIEW", "POV"]);
+const AR_TOKENS = [...VALID_AR];
+const SHOT_TOKENS = [...VALID_SHOT];
 
-// Fallback defaults if the bot gives us something invalid
+// Hard fallback defaults if settings are unavailable
 const DEFAULT_AR   = "PORTRAIT";
 const DEFAULT_SHOT = "WIDE";
+const DEFAULT_SEED = "RANDOM";
+
+// Prevent toast spam in messages with many repaired markers
+let lastRepairToastAt = 0;
+const REPAIR_TOAST_COOLDOWN_MS = 3000;
 
 // Regex to match [[IMG: ... ]] — captures everything inside (non-global, for single match)
 export const MARKER_REGEX = /\[\[IMG:\s*(.+?)\s*\]\]/s;
@@ -29,43 +37,149 @@ export function hasImageMarker(text) {
  * Does NOT trigger generation — just validates and resolves values.
  * @param {string} innerContent - The text between [[IMG: and ]]
  * @param {number} messageIndex - The message index (needed for LOCK seed resolution)
- * @returns {{ prompt: string, ar: string, shot: string, seed: number } | null}
+ * @returns {{ status: "ok", prompt: string, ar: string, shot: string, seed: number, repairMeta: {defaulted: string[], duplicatesIgnored: string[]} } | { status: "parse_error", reason: string, repairMeta: {defaulted: string[], duplicatesIgnored: string[]} }}
  */
 function parseMarkerContent(innerContent, messageIndex) {
-    // Split the inner content by | into exactly 4 segments
-    const segments = innerContent.split("|").map(s => s.trim());
+    const segments = innerContent
+        .split("|")
+        .map(s => s.trim())
+        .filter(Boolean);
 
-    if (segments.length !== 4) {
-        console.warn(`[ComfyInject] Marker has ${segments.length} segment(s), expected 4. Skipping.`);
-        return null;
+    const repairMeta = {
+        defaulted: [],
+        duplicatesIgnored: [],
+    };
+
+    const defaults = getMarkerDefaults();
+
+    const promptParts = [];
+    let ar = null;
+    let shot = null;
+    let seedToken = null;
+
+    for (const segment of segments) {
+        const upper = segment.toUpperCase();
+        const seedKind = classifySeed(upper);
+
+        if (VALID_AR.has(upper)) {
+            if (ar === null) {
+                ar = upper;
+            } else {
+                repairMeta.duplicatesIgnored.push(`AR=${upper}`);
+                console.warn(`[ComfyInject] Duplicate AR "${upper}" ignored.`);
+            }
+            continue;
+        }
+
+        if (VALID_SHOT.has(upper)) {
+            if (shot === null) {
+                shot = upper;
+            } else {
+                repairMeta.duplicatesIgnored.push(`SHOT=${upper}`);
+                console.warn(`[ComfyInject] Duplicate SHOT "${upper}" ignored.`);
+            }
+            continue;
+        }
+
+        if (seedKind) {
+            if (seedToken === null) {
+                seedToken = upper;
+            } else {
+                repairMeta.duplicatesIgnored.push(`SEED=${upper}`);
+                console.warn(`[ComfyInject] Duplicate SEED "${upper}" ignored.`);
+            }
+            continue;
+        }
+
+        promptParts.push(segment);
     }
 
-    const [rawPrompt, rawAR, rawShot, rawSeed] = segments;
+    const prompt = promptParts.join(", ").trim();
 
-    // Validate prompt — if empty we really can't do anything useful
-    if (!rawPrompt) {
-        console.warn("[ComfyInject] Marker has an empty prompt. Skipping.");
-        return null;
+    // Empty prompt is the only parser hard-fail.
+    if (!prompt) {
+        console.warn("[ComfyInject] Marker invalid: empty prompt.");
+        return {
+            status: "parse_error",
+            reason: "empty_prompt",
+            repairMeta,
+        };
     }
 
-    // Validate AR — fall back to default if invalid
-    let ar = rawAR.toUpperCase();
-    if (!VALID_AR.has(ar)) {
-        console.warn(`[ComfyInject] Invalid AR "${rawAR}", falling back to ${DEFAULT_AR}`);
-        ar = DEFAULT_AR;
+    if (ar === null) {
+        ar = defaults.ar;
+        repairMeta.defaulted.push(`AR=${ar}`);
     }
 
-    // Validate SHOT — fall back to default if invalid
-    let shot = rawShot.toUpperCase();
-    if (!VALID_SHOT.has(shot)) {
-        console.warn(`[ComfyInject] Invalid SHOT "${rawShot}", falling back to ${DEFAULT_SHOT}`);
-        shot = DEFAULT_SHOT;
+    if (shot === null) {
+        shot = defaults.shot;
+        repairMeta.defaulted.push(`SHOT=${shot}`);
     }
 
-    // Resolve seed — handles RANDOM, LOCK, and integer strings
-    const seed = resolveSeed(rawSeed.toUpperCase(), messageIndex);
+    if (seedToken === null) {
+        seedToken = defaults.seed;
+        repairMeta.defaulted.push(`SEED=${seedToken}`);
+    }
 
-    return { prompt: rawPrompt, ar, shot, seed };
+    const seed = resolveSeed(seedToken, messageIndex);
+
+    return {
+        status: "ok",
+        prompt,
+        ar,
+        shot,
+        seed,
+        repairMeta,
+    };
+}
+
+function classifySeed(value) {
+    if (value === "RANDOM" || value === "LOCK") return value;
+    if (/^\d+$/.test(value)) return "INTEGER";
+    return null;
+}
+
+function chooseRandom(list) {
+    return list[Math.floor(Math.random() * list.length)];
+}
+
+function getMarkerDefaults() {
+    const settings = getSettings();
+
+    const rawAr = String(settings.default_ar ?? DEFAULT_AR).toUpperCase();
+    const rawShot = String(settings.default_shot ?? DEFAULT_SHOT).toUpperCase();
+    const rawSeed = String(settings.default_seed ?? DEFAULT_SEED).toUpperCase();
+
+    const ar = rawAr === "RANDOM"
+        ? chooseRandom(AR_TOKENS)
+        : (VALID_AR.has(rawAr) ? rawAr : DEFAULT_AR);
+
+    const shot = rawShot === "RANDOM"
+        ? chooseRandom(SHOT_TOKENS)
+        : (VALID_SHOT.has(rawShot) ? rawShot : DEFAULT_SHOT);
+
+    const seed = classifySeed(rawSeed) ? rawSeed : DEFAULT_SEED;
+
+    return { ar, shot, seed };
+}
+
+function getSettings() {
+    const context = globalThis.SillyTavern?.getContext?.();
+    const settings = context?.extensionSettings?.[MODULE_NAME] ?? {};
+    return settings;
+}
+
+function maybeShowRepairToast(markerIndex, repairMeta) {
+    if (!repairMeta.defaulted.length) return;
+
+    const now = Date.now();
+    if (now - lastRepairToastAt < REPAIR_TOAST_COOLDOWN_MS) return;
+    lastRepairToastAt = now;
+
+    const msg = `Repaired marker #${markerIndex}: defaulted ${repairMeta.defaulted.join(", ")}`;
+    if (globalThis.toastr?.warning) {
+        globalThis.toastr.warning(msg, "ComfyInject");
+    }
 }
 
 /**
@@ -74,7 +188,7 @@ function parseMarkerContent(innerContent, messageIndex) {
  *
  * @param {string} text - Raw message text potentially containing multiple markers
  * @param {number} messageIndex - The index of the message being processed
- * @returns {Promise<Array<{imageUrl: string, seed: number, prompt: string, ar: string, shot: string}>>}
+ * @returns {Promise<Array<{status: "ok", imageUrl: string, seed: number, prompt: string, ar: string, shot: string} | {status: "parse_error", reason: string} | {status: "generation_error"}>>}
  */
 export async function processAllImageMarkers(text, messageIndex) {
     const matches = [...text.matchAll(MARKER_REGEX_GLOBAL)];
@@ -86,13 +200,30 @@ export async function processAllImageMarkers(text, messageIndex) {
 
     const results = [];
 
-    for (const match of matches) {
+    for (let markerIdx = 0; markerIdx < matches.length; markerIdx++) {
+        const match = matches[markerIdx];
         const parsed = parseMarkerContent(match[1], messageIndex);
-        if (!parsed) continue;
+        const markerNumber = markerIdx + 1;
 
-        const { prompt, ar, shot, seed } = parsed;
+        if (!parsed || parsed.status === "parse_error") {
+            results.push({
+                status: "parse_error",
+                reason: parsed?.reason ?? "unknown",
+            });
+            continue;
+        }
 
-        console.log(`[ComfyInject] Parsed marker ${results.length + 1}/${matches.length} — prompt: "${prompt}" | AR: ${ar} | SHOT: ${shot} | seed: ${seed}`);
+        const { prompt, ar, shot, seed, repairMeta } = parsed;
+
+        if (repairMeta.defaulted.length || repairMeta.duplicatesIgnored.length) {
+            const details = [];
+            if (repairMeta.defaulted.length) details.push(`defaulted=[${repairMeta.defaulted.join(", ")}]`);
+            if (repairMeta.duplicatesIgnored.length) details.push(`duplicates_ignored=[${repairMeta.duplicatesIgnored.join(", ")}]`);
+            console.warn(`[ComfyInject] Marker ${markerNumber} repaired: ${details.join(" ")} -> (${ar}, ${shot}, ${seed})`);
+            maybeShowRepairToast(markerNumber, repairMeta);
+        }
+
+        console.log(`[ComfyInject] Parsed marker ${markerNumber}/${matches.length} - prompt: "${prompt}" | AR: ${ar} | SHOT: ${shot} | seed: ${seed}`);
 
         try {
             const result = await generateImage({
@@ -106,11 +237,10 @@ export async function processAllImageMarkers(text, messageIndex) {
             // Save the seed that was actually used so LOCK works
             saveLastSeed(result.seed);
 
-            results.push({ ...result, ar, shot });
+            results.push({ status: "ok", ...result, ar, shot });
         } catch (err) {
-            console.error(`[ComfyInject] Image generation failed for marker ${results.length + 1}:`, err);
-            // Push null so the index stays aligned with the marker positions
-            results.push(null);
+            console.error(`[ComfyInject] Image generation failed for marker ${markerNumber}:`, err);
+            results.push({ status: "generation_error" });
         }
     }
 

--- a/src/parse.js
+++ b/src/parse.js
@@ -1,31 +1,41 @@
 import { generateImage } from "./comfy.js";
 import { resolveSeed, saveLastSeed } from "./state.js";
-import { MODULE_NAME } from "../settings.js";
 
-// Valid values for AR and SHOT tokens
-const VALID_AR   = new Set(["PORTRAIT", "SQUARE", "LANDSCAPE", "CINEMA"]);
-const VALID_SHOT = new Set(["CLOSE", "MEDIUM", "WIDE", "DUTCH", "OVERHEAD", "LOWANGLE", "HIGHANGLE", "PROFILE", "BACKVIEW", "POV"]);
-const AR_TOKENS = [...VALID_AR];
-const SHOT_TOKENS = [...VALID_SHOT];
+// Valid AR control tokens.
+// These must match exactly and stay case-sensitive.
+const VALID_AR = new Set(["PORTRAIT", "SQUARE", "LANDSCAPE", "CINEMA"]);
 
-// Hard fallback defaults if settings are unavailable
-const DEFAULT_AR   = "PORTRAIT";
-const DEFAULT_SHOT = "WIDE";
+// Valid SHOT control tokens.
+// These must match exactly and stay case-sensitive.
+const VALID_SHOT = new Set([
+    "CLOSE",
+    "MEDIUM",
+    "WIDE",
+    "DUTCH",
+    "OVERHEAD",
+    "LOWANGLE",
+    "HIGHANGLE",
+    "PROFILE",
+    "BACKVIEW",
+    "POV",
+]);
+
+// Marker-level fallback values.
+// These are only used when the marker does not provide a usable value.
+// Final generation can still be overridden later by locks.
+const DEFAULT_AR = "SQUARE";
+const DEFAULT_SHOT = "MEDIUM";
 const DEFAULT_SEED = "RANDOM";
 
-// Prevent toast spam in messages with many repaired markers
-let lastRepairToastAt = 0;
-const REPAIR_TOAST_COOLDOWN_MS = 3000;
-
-// Regex to match [[IMG: ... ]] — captures everything inside (non-global, for single match)
+// Regex to match a single [[IMG: ... ]] marker.
 export const MARKER_REGEX = /\[\[IMG:\s*(.+?)\s*\]\]/s;
 
-// Global version for finding all markers in a message
+// Global regex to find all markers in a message.
 const MARKER_REGEX_GLOBAL = /\[\[IMG:\s*(.+?)\s*\]\]/gs;
 
 /**
- * Checks whether a message string contains an [[IMG: ... ]] marker.
- * @param {string} text - Raw message text
+ * Returns true if the message contains at least one image marker.
+ * @param {string} text
  * @returns {boolean}
  */
 export function hasImageMarker(text) {
@@ -33,72 +43,309 @@ export function hasImageMarker(text) {
 }
 
 /**
- * Parses the inner content of a single [[IMG: ... ]] marker into its components.
- * Does NOT trigger generation — just validates and resolves values.
- * @param {string} innerContent - The text between [[IMG: and ]]
- * @param {number} messageIndex - The message index (needed for LOCK seed resolution)
- * @returns {{ status: "ok", prompt: string, ar: string, shot: string, seed: number, repairMeta: {defaulted: string[], duplicatesIgnored: string[]} } | { status: "parse_error", reason: string, repairMeta: {defaulted: string[], duplicatesIgnored: string[]} }}
+ * Returns true if the value is an exact AR token.
+ * @param {string} value
+ * @returns {boolean}
  */
-function parseMarkerContent(innerContent, messageIndex) {
-    const segments = innerContent
-        .split("|")
-        .map(s => s.trim())
-        .filter(Boolean);
+function isArToken(value) {
+    return VALID_AR.has(value);
+}
 
-    const repairMeta = {
+/**
+ * Returns true if the value is an exact SHOT token.
+ * @param {string} value
+ * @returns {boolean}
+ */
+function isShotToken(value) {
+    return VALID_SHOT.has(value);
+}
+
+/**
+ * Returns true if the value is an exact SEED token.
+ * Valid seed tokens are RANDOM, LOCK, or a digits-only integer string.
+ * @param {string} value
+ * @returns {boolean}
+ */
+function isSeedToken(value) {
+    return value === "RANDOM" || value === "LOCK" || /^\d+$/.test(value);
+}
+
+/**
+ * Classifies a token candidate as AR, SHOT, SEED, or null.
+ * Matching is exact and case-sensitive.
+ * @param {string} value
+ * @returns {"AR" | "SHOT" | "SEED" | null}
+ */
+function classifyToken(value) {
+    if (isArToken(value)) return "AR";
+    if (isShotToken(value)) return "SHOT";
+    if (isSeedToken(value)) return "SEED";
+    return null;
+}
+
+/**
+ * Returns a fresh repair metadata object for one marker parse.
+ * This tracks what was defaulted, what duplicates were ignored,
+ * and any prompt warnings.
+ * @returns {{
+ *   defaulted: string[],
+ *   duplicateTokens: {
+ *     AR: string[],
+ *     SHOT: string[],
+ *     SEED: string[]
+ *   },
+ *   possibleSeedInPrompt: boolean
+ * }}
+ */
+function createRepairMeta() {
+    return {
         defaulted: [],
-        duplicatesIgnored: [],
+        duplicateTokens: {
+            AR: [],
+            SHOT: [],
+            SEED: [],
+        },
+        possibleSeedInPrompt: false,
     };
+}
 
-    const defaults = getMarkerDefaults();
-
-    const promptParts = [];
-    let ar = null;
-    let shot = null;
-    let seedToken = null;
-
-    for (const segment of segments) {
-        const upper = segment.toUpperCase();
-        const seedKind = classifySeed(upper);
-
-        if (VALID_AR.has(upper)) {
-            if (ar === null) {
-                ar = upper;
-            } else {
-                repairMeta.duplicatesIgnored.push(`AR=${upper}`);
-                console.warn(`[ComfyInject] Duplicate AR "${upper}" ignored.`);
-            }
-            continue;
+/**
+ * Records a token into parser state.
+ * First valid token wins for each field.
+ * Later duplicates are ignored and tracked in repairMeta.
+ * @param {{ ar: string | null, shot: string | null, seedToken: string | null }} state
+ * @param {"AR" | "SHOT" | "SEED"} type
+ * @param {string} value
+ * @param {ReturnType<typeof createRepairMeta>} repairMeta
+ */
+function recordToken(state, type, value, repairMeta) {
+    if (type === "AR") {
+        if (state.ar === null) {
+            state.ar = value;
+        } else {
+            repairMeta.duplicateTokens.AR.push(value);
         }
-
-        if (VALID_SHOT.has(upper)) {
-            if (shot === null) {
-                shot = upper;
-            } else {
-                repairMeta.duplicatesIgnored.push(`SHOT=${upper}`);
-                console.warn(`[ComfyInject] Duplicate SHOT "${upper}" ignored.`);
-            }
-            continue;
-        }
-
-        if (seedKind) {
-            if (seedToken === null) {
-                seedToken = upper;
-            } else {
-                repairMeta.duplicatesIgnored.push(`SEED=${upper}`);
-                console.warn(`[ComfyInject] Duplicate SEED "${upper}" ignored.`);
-            }
-            continue;
-        }
-
-        promptParts.push(segment);
+        return;
     }
 
-    const prompt = promptParts.join(", ").trim();
+    if (type === "SHOT") {
+        if (state.shot === null) {
+            state.shot = value;
+        } else {
+            repairMeta.duplicateTokens.SHOT.push(value);
+        }
+        return;
+    }
 
-    // Empty prompt is the only parser hard-fail.
+    if (type === "SEED") {
+        if (state.seedToken === null) {
+            state.seedToken = value;
+        } else {
+            repairMeta.duplicateTokens.SEED.push(value);
+        }
+    }
+}
+
+/**
+ * Optional warning only.
+ * This does NOT parse numbers out of prompt text.
+ * It only flags that the final prompt still contains a large standalone number.
+ * @param {string} prompt
+ * @returns {boolean}
+ */
+function hasPossibleSeedInPrompt(prompt) {
+    return /\b\d{4,}\b/.test(prompt);
+}
+
+/**
+ * Processes a single whitespace-separated word.
+ * At the word level, only exact uppercase control tokens are consumed.
+ * Numeric seeds are NOT consumed here, so numbers inside prompt-like text
+ * remain part of the prompt instead of being parsed as SEED.
+ * @param {string} word
+ * @param {{ ar: string | null, shot: string | null, seedToken: string | null }} state
+ * @param {ReturnType<typeof createRepairMeta>} repairMeta
+ * @returns {string}
+ */
+function processWord(word, state, repairMeta) {
+    let type = null;
+
+    if (isArToken(word)) {
+        type = "AR";
+    } else if (isShotToken(word)) {
+        type = "SHOT";
+    } else if (word === "RANDOM" || word === "LOCK") {
+        type = "SEED";
+    }
+
+    if (!type) {
+        return word;
+    }
+
+    recordToken(state, type, word, repairMeta);
+    return "";
+}
+
+/**
+ * Processes one comma-separated part of a segment.
+ *
+ * Priority:
+ * 1. If the whole part is an exact token, consume it.
+ * 2. If the whole part is digits-only, consume it as a seed token.
+ * 3. Otherwise split on whitespace and consume exact uppercase tokens word-by-word.
+ * 4. Any leftover text remains prompt content.
+ *
+ * Leftover words inside the same comma part are rejoined with spaces.
+ *
+ * @param {string} part
+ * @param {{ ar: string | null, shot: string | null, seedToken: string | null }} state
+ * @param {ReturnType<typeof createRepairMeta>} repairMeta
+ * @returns {string}
+ */
+function processCommaPart(part, state, repairMeta) {
+    const trimmed = part.trim();
+    if (!trimmed) return "";
+
+    const wholeType = classifyToken(trimmed);
+    if (wholeType) {
+        recordToken(state, wholeType, trimmed, repairMeta);
+        return "";
+    }
+
+    if (/^\d+$/.test(trimmed)) {
+        recordToken(state, "SEED", trimmed, repairMeta);
+        return "";
+    }
+
+    const words = trimmed.split(/\s+/).filter(Boolean);
+    const leftoverWords = [];
+
+    for (const word of words) {
+        const leftover = processWord(word, state, repairMeta);
+        if (leftover) {
+            leftoverWords.push(leftover);
+        }
+    }
+
+    return leftoverWords.join(" ");
+}
+
+/**
+ * Processes one pipe-separated segment.
+ *
+ * Priority:
+ * 1. If the whole segment is an exact token, consume it.
+ * 2. If the whole segment is digits-only, consume it as a seed token.
+ * 3. Otherwise split on commas and process each comma part.
+ * 4. Any leftover text remains prompt content.
+ *
+ * Leftover comma parts inside the same segment are rejoined with commas.
+ *
+ * @param {string} segment
+ * @param {{ ar: string | null, shot: string | null, seedToken: string | null }} state
+ * @param {ReturnType<typeof createRepairMeta>} repairMeta
+ * @returns {string}
+ */
+function processSegment(segment, state, repairMeta) {
+    const trimmed = segment.trim();
+    if (!trimmed) return "";
+
+    const wholeType = classifyToken(trimmed);
+    if (wholeType) {
+        recordToken(state, wholeType, trimmed, repairMeta);
+        return "";
+    }
+
+    if (/^\d+$/.test(trimmed)) {
+        recordToken(state, "SEED", trimmed, repairMeta);
+        return "";
+    }
+
+    const commaParts = trimmed.split(",");
+    const leftoverParts = [];
+
+    for (const part of commaParts) {
+        const leftover = processCommaPart(part, state, repairMeta);
+        if (leftover) {
+            leftoverParts.push(leftover);
+        }
+    }
+
+    return leftoverParts.join(", ");
+}
+
+/**
+ * Parses one [[IMG: ... ]] marker.
+ *
+ * The marker format is a recommendation, not a hard rule.
+ * The parser scans every pipe-separated segment and tries to salvage exact
+ * uppercase control tokens from whole segments, comma parts, and words.
+ *
+ * Whatever is not consumed as AR / SHOT / SEED remains prompt text.
+ * Prompt leftovers from different pipe segments are rejoined with commas.
+ *
+ * @param {string} innerContent
+ * @param {number} messageIndex
+ * @returns {{
+ *   status: "ok",
+ *   prompt: string,
+ *   ar: string,
+ *   shot: string,
+ *   seed: number,
+ *   repairMeta: {
+ *     defaulted: string[],
+ *     duplicateTokens: {
+ *       AR: string[],
+ *       SHOT: string[],
+ *       SEED: string[]
+ *     },
+ *     possibleSeedInPrompt: boolean
+ *   }
+ * } | {
+ *   status: "parse_error",
+ *   reason: string,
+ *   repairMeta: {
+ *     defaulted: string[],
+ *     duplicateTokens: {
+ *       AR: string[],
+ *       SHOT: string[],
+ *       SEED: string[]
+ *     },
+ *     possibleSeedInPrompt: boolean
+ *   }
+ * }}
+ */
+function parseMarkerContent(innerContent, messageIndex) {
+    const rawSegments = innerContent.split("|");
+    const repairMeta = createRepairMeta();
+    if (!innerContent.trim()) {
+        return {
+            status: "parse_error",
+            reason: "empty_marker",
+            repairMeta,
+        };
+    }
+
+    const state = {
+        ar: null,
+        shot: null,
+        seedToken: null,
+    };
+
+    const promptSegments = [];
+
+    for (const rawSegment of rawSegments) {
+        const leftover = processSegment(rawSegment, state, repairMeta);
+        if (leftover) {
+            promptSegments.push(leftover);
+        }
+    }
+
+    // Leftover text from different pipe segments becomes one final prompt.
+    // Pipes are marker syntax only, so they should not appear in the prompt sent to ComfyUI.
+    const prompt = promptSegments.join(", ").trim();
+
     if (!prompt) {
-        console.warn("[ComfyInject] Marker invalid: empty prompt.");
         return {
             status: "parse_error",
             reason: "empty_prompt",
@@ -106,19 +353,27 @@ function parseMarkerContent(innerContent, messageIndex) {
         };
     }
 
+    if (hasPossibleSeedInPrompt(prompt)) {
+        repairMeta.possibleSeedInPrompt = true;
+    }
+
+    let ar = state.ar;
+    let shot = state.shot;
+    let seedToken = state.seedToken;
+
     if (ar === null) {
-        ar = defaults.ar;
-        repairMeta.defaulted.push(`AR=${ar}`);
+        ar = DEFAULT_AR;
+        repairMeta.defaulted.push("AR");
     }
 
     if (shot === null) {
-        shot = defaults.shot;
-        repairMeta.defaulted.push(`SHOT=${shot}`);
+        shot = DEFAULT_SHOT;
+        repairMeta.defaulted.push("SHOT");
     }
 
     if (seedToken === null) {
-        seedToken = defaults.seed;
-        repairMeta.defaulted.push(`SEED=${seedToken}`);
+        seedToken = DEFAULT_SEED;
+        repairMeta.defaulted.push("SEED");
     }
 
     const seed = resolveSeed(seedToken, messageIndex);
@@ -133,97 +388,92 @@ function parseMarkerContent(innerContent, messageIndex) {
     };
 }
 
-function classifySeed(value) {
-    if (value === "RANDOM" || value === "LOCK") return value;
-    if (/^\d+$/.test(value)) return "INTEGER";
-    return null;
-}
-
-function chooseRandom(list) {
-    return list[Math.floor(Math.random() * list.length)];
-}
-
-function getMarkerDefaults() {
-    const settings = getSettings();
-
-    const rawAr = String(settings.default_ar ?? DEFAULT_AR).toUpperCase();
-    const rawShot = String(settings.default_shot ?? DEFAULT_SHOT).toUpperCase();
-    const rawSeed = String(settings.default_seed ?? DEFAULT_SEED).toUpperCase();
-
-    const ar = rawAr === "RANDOM"
-        ? chooseRandom(AR_TOKENS)
-        : (VALID_AR.has(rawAr) ? rawAr : DEFAULT_AR);
-
-    const shot = rawShot === "RANDOM"
-        ? chooseRandom(SHOT_TOKENS)
-        : (VALID_SHOT.has(rawShot) ? rawShot : DEFAULT_SHOT);
-
-    const seed = classifySeed(rawSeed) ? rawSeed : DEFAULT_SEED;
-
-    return { ar, shot, seed };
-}
-
-function getSettings() {
-    const context = globalThis.SillyTavern?.getContext?.();
-    const settings = context?.extensionSettings?.[MODULE_NAME] ?? {};
-    return settings;
-}
-
-function maybeShowRepairToast(markerIndex, repairMeta) {
-    if (!repairMeta.defaulted.length) return;
-
-    const now = Date.now();
-    if (now - lastRepairToastAt < REPAIR_TOAST_COOLDOWN_MS) return;
-    lastRepairToastAt = now;
-
-    const msg = `Repaired marker #${markerIndex}: defaulted ${repairMeta.defaulted.join(", ")}`;
-    if (globalThis.toastr?.warning) {
-        globalThis.toastr.warning(msg, "ComfyInject");
-    }
-}
-
 /**
- * Finds ALL [[IMG: ... ]] markers in a message, processes them sequentially,
- * and returns an array of results.
+ * Finds all image markers in a message, parses them one by one,
+ * and returns structured results for DOM handling.
  *
- * @param {string} text - Raw message text potentially containing multiple markers
- * @param {number} messageIndex - The index of the message being processed
- * @returns {Promise<Array<{status: "ok", imageUrl: string, seed: number, prompt: string, ar: string, shot: string} | {status: "parse_error", reason: string} | {status: "generation_error"}>>}
+ * Success:
+ *   { status: "ok", ... }
+ *
+ * Parse failure:
+ *   { status: "parse_error", reason, repairMeta, rawMarker }
+ *
+ * Generation failure:
+ *   { status: "generation_error", repairMeta, rawMarker }
+ *
+ * @param {string} text
+ * @param {number} messageIndex
+ * @returns {Promise<Array<
+ *   | {
+ *       status: "ok",
+ *       imageUrl: string,
+ *       seed: number,
+ *       prompt: string,
+ *       promptId: string,
+ *       filename: string,
+ *       effectiveAr: string,
+ *       effectiveShot: string,
+ *       resolution: { width: number, height: number },
+ *       shotTags: string,
+ *       ar: string,
+ *       shot: string,
+ *       repairMeta: {
+ *         defaulted: string[],
+ *         duplicateTokens: {
+ *           AR: string[],
+ *           SHOT: string[],
+ *           SEED: string[]
+ *         },
+ *         possibleSeedInPrompt: boolean
+ *       }
+ *     }
+ *   | {
+ *       status: "parse_error",
+ *       reason: string,
+ *       repairMeta: {
+ *         defaulted: string[],
+ *         duplicateTokens: {
+ *           AR: string[],
+ *           SHOT: string[],
+ *           SEED: string[]
+ *         },
+ *         possibleSeedInPrompt: boolean
+ *       },
+ *       rawMarker: string
+ *     }
+ *   | {
+ *       status: "generation_error",
+ *       repairMeta: {
+ *         defaulted: string[],
+ *         duplicateTokens: {
+ *           AR: string[],
+ *           SHOT: string[],
+ *           SEED: string[]
+ *         },
+ *         possibleSeedInPrompt: boolean
+ *       },
+ *       rawMarker: string
+ *     }
+ * >>}
  */
 export async function processAllImageMarkers(text, messageIndex) {
     const matches = [...text.matchAll(MARKER_REGEX_GLOBAL)];
-
-    if (matches.length === 0) {
-        console.warn("[ComfyInject] processAllImageMarkers called but no markers found");
-        return [];
-    }
+    if (matches.length === 0) return [];
 
     const results = [];
 
-    for (let markerIdx = 0; markerIdx < matches.length; markerIdx++) {
-        const match = matches[markerIdx];
+    for (const match of matches) {
         const parsed = parseMarkerContent(match[1], messageIndex);
-        const markerNumber = markerIdx + 1;
 
-        if (!parsed || parsed.status === "parse_error") {
+        if (parsed.status === "parse_error") {
             results.push({
-                status: "parse_error",
-                reason: parsed?.reason ?? "unknown",
+                ...parsed,
+                rawMarker: match[0],
             });
             continue;
         }
 
         const { prompt, ar, shot, seed, repairMeta } = parsed;
-
-        if (repairMeta.defaulted.length || repairMeta.duplicatesIgnored.length) {
-            const details = [];
-            if (repairMeta.defaulted.length) details.push(`defaulted=[${repairMeta.defaulted.join(", ")}]`);
-            if (repairMeta.duplicatesIgnored.length) details.push(`duplicates_ignored=[${repairMeta.duplicatesIgnored.join(", ")}]`);
-            console.warn(`[ComfyInject] Marker ${markerNumber} repaired: ${details.join(" ")} -> (${ar}, ${shot}, ${seed})`);
-            maybeShowRepairToast(markerNumber, repairMeta);
-        }
-
-        console.log(`[ComfyInject] Parsed marker ${markerNumber}/${matches.length} - prompt: "${prompt}" | AR: ${ar} | SHOT: ${shot} | seed: ${seed}`);
 
         try {
             const result = await generateImage({
@@ -234,13 +484,22 @@ export async function processAllImageMarkers(text, messageIndex) {
                 messageIndex,
             });
 
-            // Save the seed that was actually used so LOCK works
+            // Save the actual used seed so LOCK can reuse it later.
             saveLastSeed(result.seed);
 
-            results.push({ status: "ok", ...result, ar, shot });
-        } catch (err) {
-            console.error(`[ComfyInject] Image generation failed for marker ${markerNumber}:`, err);
-            results.push({ status: "generation_error" });
+            results.push({
+                status: "ok",
+                ...result,
+                ar,
+                shot,
+                repairMeta,
+            });
+        } catch {
+            results.push({
+                status: "generation_error",
+                repairMeta,
+                rawMarker: match[0],
+            });
         }
     }
 

--- a/src/state.js
+++ b/src/state.js
@@ -11,12 +11,37 @@ let lastSeed = null;
  * Key can be a send_date string (new) or a numeric index (old/legacy).
  * @param {object} metadata - The chatMetadata[MODULE_NAME] object
  * @param {string|number} key - The metadata key (send_date or legacy index)
- * @returns {Array<{seed: number, ar?: string, shot?: string, promptId?: string, filename?: string}>}
+ * @returns {Array<object>}
  */
 export function getImageData(metadata, key) {
     const data = metadata?.[key];
     if (!data) return [];
     return Array.isArray(data) ? data : [data];
+}
+
+/**
+ * Extracts the most recent seed from the currently saved <img> tags in a message.
+ * This is used as a fallback for newer chats where seed is no longer stored in metadata.
+ * Walks backward so the most recent image in the message wins.
+ * @param {object} message - A SillyTavern chat message object
+ * @returns {number|null} The parsed seed from the last saved image tag, or null if none found
+ */
+function getSeedFromMessageMes(message) {
+    if (!message?.mes || typeof message.mes !== "string") return null;
+
+    const imgTags = [...message.mes.matchAll(/<img class="comfyinject-image"[^>]*>/g)];
+    if (imgTags.length === 0) return null;
+
+    for (let i = imgTags.length - 1; i >= 0; i--) {
+        const tag = imgTags[i][0];
+        const seedMatch = tag.match(/data-seed="([^"]*)"/);
+        const parsedSeed = parseInt(seedMatch?.[1], 10);
+        if (Number.isFinite(parsedSeed)) {
+            return parsedSeed;
+        }
+    }
+
+    return null;
 }
 
 /**
@@ -39,12 +64,35 @@ function getLastSavedSeed(currentIndex) {
         const message = context.chat[i];
         if (!message) continue;
 
-        // Try send_date key first (new format), then index key (legacy)
-        const key = message.send_date || i;
-        const images = getImageData(metadata, key);
+        // First try metadata seed lookup.
+        // This remains authoritative for legacy chats because older <img> tags
+        // may contain the LLM-written seed instead of the actual seed used.
+        let images = getImageData(metadata, message.send_date);
+
+        if (images.length === 0) {
+            images = getImageData(metadata, i);
+        }
+
         if (images.length > 0) {
-            // Use the seed from the last image in the message
-            return images[images.length - 1].seed;
+            // Walk backward through the saved image metadata for this message
+            // so null entries or malformed objects do not crash LOCK lookup.
+            // Accept both numeric seeds and numeric strings for backward compatibility.
+            for (let j = images.length - 1; j >= 0; j--) {
+                const image = images[j];
+                if (!image || typeof image !== "object") continue;
+
+                const parsedSeed = parseInt(image.seed, 10);
+                if (Number.isFinite(parsedSeed)) {
+                    return parsedSeed;
+                }
+            }
+        }
+
+        // Fall back to the currently saved <img> tags in message.mes.
+        // This supports newer chats where seed is no longer stored in metadata.
+        const mesSeed = getSeedFromMessageMes(message);
+        if (mesSeed !== null) {
+            return mesSeed;
         }
     }
 
@@ -67,7 +115,8 @@ export function resolveSeed(seed, currentIndex) {
     }
 
     if (seed === "LOCK") {
-        // Try metadata first — this is the authoritative source
+        // Try the last saved seed from prior messages.
+        // This prefers metadata for legacy chats, then falls back to saved <img> tags.
         if (currentIndex !== undefined) {
             const savedSeed = getLastSavedSeed(currentIndex);
             if (savedSeed !== null) return savedSeed;
@@ -101,10 +150,10 @@ export function saveLastSeed(seed) {
 }
 
 /**
- * Generates a random integer seed in ComfyUI's expected range.
+ * Generates a random integer seed in the project-wide seed range.
  * @returns {number}
  */
 function generateRandomSeed() {
-    // ComfyUI accepts seeds up to 2^32 - 1
-    return Math.floor(Math.random() * 4294967295);
+    // Use the project-wide max safe integer seed range.
+    return Math.floor(Math.random() * 9007199254740991);
 }

--- a/src/ui.js
+++ b/src/ui.js
@@ -117,6 +117,14 @@ function updateSeedLockUI(locked) {
 }
 
 /**
+ * Shows or hides marker default custom seed input based on selected mode.
+ * @param {string} mode - RANDOM, LOCK, or CUSTOM
+ */
+function updateDefaultSeedUI(mode) {
+    $("#comfyinject_default_seed_custom_input").toggle(mode === "CUSTOM");
+}
+
+/**
  * Populates all input fields from current settings.
  */
 function populateUI() {
@@ -187,6 +195,16 @@ function populateUI() {
     $("#comfyinject_seed_lock_mode").val(settings.seed_lock_mode);
     $("#comfyinject_seed_lock_value").val(settings.seed_lock_value);
     updateSeedLockUI(settings.seed_lock_enabled);
+
+    // Marker defaults
+    $("#comfyinject_default_ar").val(settings.default_ar || "RANDOM");
+    $("#comfyinject_default_shot").val(settings.default_shot || "RANDOM");
+
+    const defaultSeed = settings.default_seed ?? "RANDOM";
+    const defaultSeedMode = /^\d+$/.test(String(defaultSeed)) ? "CUSTOM" : String(defaultSeed).toUpperCase();
+    $("#comfyinject_default_seed_mode").val(defaultSeedMode);
+    $("#comfyinject_default_seed_value").val(defaultSeedMode === "CUSTOM" ? parseInt(defaultSeed, 10) : 0);
+    updateDefaultSeedUI(defaultSeedMode);
 
     // Populate shot tags
     const shotContainer = $("#comfyinject_shot_tags");
@@ -407,6 +425,11 @@ function wireEvents() {
         $("#comfyinject_seed_lock_block").toggle();
     });
 
+    // Marker defaults toggle
+    $("#comfyinject_marker_defaults_toggle").on("click", function () {
+        $("#comfyinject_marker_defaults_block").toggle();
+    });
+
     // Seed lock — toggle
     $("#comfyinject_seed_lock_enabled").on("change", function () {
         const locked = $(this).prop("checked");
@@ -426,6 +449,41 @@ function wireEvents() {
     // Seed lock — custom value
     $("#comfyinject_seed_lock_value").on("input", function () {
         getSettings().seed_lock_value = parseInt($(this).val(), 10);
+        saveSettings();
+    });
+
+    // Marker defaults — AR
+    $("#comfyinject_default_ar").on("change", function () {
+        getSettings().default_ar = $(this).val();
+        saveSettings();
+    });
+
+    // Marker defaults — SHOT
+    $("#comfyinject_default_shot").on("change", function () {
+        getSettings().default_shot = $(this).val();
+        saveSettings();
+    });
+
+    // Marker defaults — SEED mode
+    $("#comfyinject_default_seed_mode").on("change", function () {
+        const mode = $(this).val();
+        updateDefaultSeedUI(mode);
+
+        if (mode === "CUSTOM") {
+            const currentVal = parseInt($("#comfyinject_default_seed_value").val(), 10);
+            getSettings().default_seed = Number.isFinite(currentVal) ? currentVal : 0;
+        } else {
+            getSettings().default_seed = mode;
+        }
+
+        saveSettings();
+    });
+
+    // Marker defaults — custom seed value
+    $("#comfyinject_default_seed_value").on("input", function () {
+        if ($("#comfyinject_default_seed_mode").val() !== "CUSTOM") return;
+        const val = parseInt($(this).val(), 10);
+        getSettings().default_seed = Number.isFinite(val) ? val : 0;
         saveSettings();
     });
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -116,13 +116,6 @@ function updateSeedLockUI(locked) {
     $("#comfyinject_seed_lock_custom_input").toggle(locked && mode === "CUSTOM");
 }
 
-/**
- * Shows or hides marker default custom seed input based on selected mode.
- * @param {string} mode - RANDOM, LOCK, or CUSTOM
- */
-function updateDefaultSeedUI(mode) {
-    $("#comfyinject_default_seed_custom_input").toggle(mode === "CUSTOM");
-}
 
 /**
  * Populates all input fields from current settings.
@@ -196,15 +189,8 @@ function populateUI() {
     $("#comfyinject_seed_lock_value").val(settings.seed_lock_value);
     updateSeedLockUI(settings.seed_lock_enabled);
 
-    // Marker defaults
-    $("#comfyinject_default_ar").val(settings.default_ar || "RANDOM");
-    $("#comfyinject_default_shot").val(settings.default_shot || "RANDOM");
-
-    const defaultSeed = settings.default_seed ?? "RANDOM";
-    const defaultSeedMode = /^\d+$/.test(String(defaultSeed)) ? "CUSTOM" : String(defaultSeed).toUpperCase();
-    $("#comfyinject_default_seed_mode").val(defaultSeedMode);
-    $("#comfyinject_default_seed_value").val(defaultSeedMode === "CUSTOM" ? parseInt(defaultSeed, 10) : 0);
-    updateDefaultSeedUI(defaultSeedMode);
+    // Marker repair notifications
+    $("#comfyinject_repair_toast_mode").val(settings.repair_toast_mode || "failures");
 
     // Populate shot tags
     const shotContainer = $("#comfyinject_shot_tags");
@@ -425,10 +411,6 @@ function wireEvents() {
         $("#comfyinject_seed_lock_block").toggle();
     });
 
-    // Marker defaults toggle
-    $("#comfyinject_marker_defaults_toggle").on("click", function () {
-        $("#comfyinject_marker_defaults_block").toggle();
-    });
 
     // Seed lock — toggle
     $("#comfyinject_seed_lock_enabled").on("change", function () {
@@ -452,38 +434,9 @@ function wireEvents() {
         saveSettings();
     });
 
-    // Marker defaults — AR
-    $("#comfyinject_default_ar").on("change", function () {
-        getSettings().default_ar = $(this).val();
-        saveSettings();
-    });
-
-    // Marker defaults — SHOT
-    $("#comfyinject_default_shot").on("change", function () {
-        getSettings().default_shot = $(this).val();
-        saveSettings();
-    });
-
-    // Marker defaults — SEED mode
-    $("#comfyinject_default_seed_mode").on("change", function () {
-        const mode = $(this).val();
-        updateDefaultSeedUI(mode);
-
-        if (mode === "CUSTOM") {
-            const currentVal = parseInt($("#comfyinject_default_seed_value").val(), 10);
-            getSettings().default_seed = Number.isFinite(currentVal) ? currentVal : 0;
-        } else {
-            getSettings().default_seed = mode;
-        }
-
-        saveSettings();
-    });
-
-    // Marker defaults — custom seed value
-    $("#comfyinject_default_seed_value").on("input", function () {
-        if ($("#comfyinject_default_seed_mode").val() !== "CUSTOM") return;
-        const val = parseInt($(this).val(), 10);
-        getSettings().default_seed = Number.isFinite(val) ? val : 0;
+    // Marker repair notifications
+    $("#comfyinject_repair_toast_mode").on("change", function () {
+        getSettings().repair_toast_mode = $(this).val();
         saveSettings();
     });
 


### PR DESCRIPTION
** Note - Vibecoded a fix for LLM's not always having all the required datapoints in the marker, GLM5 was often only adding Prompt and Seed.

Now if a datapoint is missing it will use the default (setup in settings), defaulting to Random.

--- Copilot summary ---
## Summary
This PR makes `[[IMG: ... ]]` marker parsing lenient so incomplete or out-of-order markers no longer silently stall image generation.

## What Changed
- Refactored marker parsing to classify segments by token type instead of requiring exactly 4 ordered segments.
- Added fallback defaults for missing marker fields:
  - `default_ar`
  - `default_shot`
  - `default_seed`
- Added Advanced Settings UI controls for Marker Defaults (including CUSTOM seed value).
- Added parser-specific hard-fail output for empty prompt:
  - `[Image marker invalid: empty prompt]`
- Kept generation failures distinct:
  - `[Image generation failed]`
- Added repair/default observability:
  - console warnings for repaired markers and duplicate ignored fields
  - rate-limited warning toast for defaulted markers
- Added small notes to Readme

## Behavior Notes
- Existing valid 4-field markers continue to work.
- Global seed lock remains authoritative when enabled.

## Test Coverage (manual)
- Prompt-only marker defaults AR/SHOT/SEED.
- Prompt + seed marker works.
- Out-of-order marker fields resolve correctly.
- Duplicate AR/SHOT/SEED keeps first value.
- Empty prompt marker shows parser-specific invalid marker text.
- Multi-marker messages stay aligned with replacement results.
- New Marker Defaults settings persist and reload.