### PR TITLE
Allow string placeholder insertion insead of whole string replacement

### DIFF
--- a/src/comfy.js
+++ b/src/comfy.js
@@ -39,10 +39,17 @@ async function loadWorkflow() {
  */
 function fillWorkflow(workflow, values) {
     let workflowStr = JSON.stringify(workflow);
-
     for (const [key, value] of Object.entries(values)) {
-        const placeholder = `"{{${key}}}"`;
-        const replacement = JSON.stringify(value);
+        let placeholder;
+        let replacement;
+        if (typeof value === "string") {
+            placeholder = `{{${key}}}`;
+            replacement = JSON.stringify(value).slice(1, -1);
+        }
+        else {
+            placeholder = `"{{${key}}}"`;
+            replacement = JSON.stringify(value);
+        }
         while (workflowStr.includes(placeholder)) {
             workflowStr = workflowStr.replace(placeholder, replacement);
         }


### PR DESCRIPTION
For example, have fixed prompt inside workflow template:

```JSON
{
    "inputs": {
      "text": "@yoneyama mai, @(ke-ta:0.4), {{POSITIVE_PROMPT}}",
      "clip": [
        "60:45",
        0
      ]
    },
    "class_type": "CLIPTextEncode",
    "_meta": {
      "title": "CLIP Text Encode (Positive Prompt)"
    }
}
```

So that you can have different style prompt for each workflow